### PR TITLE
Hotfix: Entity Reference issue and Rename tax code initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,22 @@ Intializers provide a way for Alice fixtures to reference entities that already 
 
 This bundle comes with the below initializers:
 
-|Initializer|Description|Example|
-|---|---|---|
-|AdminUserInitializer|First user with `ROLE_ADMINISTRATOR`|`@admin_user`|
-|CustomerUserRoleInitializer|All customer user roles|`@buyer`, `@admin`|
-|ProductUnitInitializer|All product unit codes prefixed with `unit`|`@unit_each`|
-|RootCategoryInitializer|The master catalogs root category|`@root_category`|
-|WarehouseInitializer|The snake case version of the name of each warehouse (Enterprise only) prefixed with `warehouse`|`Some Warehouse` becomes `@warehouse_some_warehouse`|
-|BusinessUnitInitializer|All of the existing business units suffixed with `_business_unit`| `North Office` becomes `@north_office_business_unit`|
-|DefaultPriceListInitializer|The default price list|`@default_price_list`|
-|OrganizationInitializer|If more than one organization exists the normalized name of of the organization prefixed by `org_`. If only one exists it is named `default_organization` |`@default_organization` or `Our Business` becomes `@org_our_business`|
-|SegmentTypeInitializer|The available segment types|`@dynamic_segment_type` or `static_segment_type`|
-|WebsiteInitializer|All website names prefixed by `website_`|`Some Store` becomes `@website_some_store`|
-|CustomerGroupInitializer|All customer group names prefixed with `group_` |`Registered Buyers` becomes `@group_registered_buyers`|
-|InventoryStatusInitializer|All inventory status ids prefixed by `inventory_status_`|`@inventory_status_in_stock` or `@inventory_status_out_of_stock`|
-|ProductFamilyInitializer|All Attribute family names prefixed with `product_family_`|`Clothing Attributes` becomes `@product_family_clothing_attributes`|
-|TaxCodeInitializer|The tax code lowercased and prefixed with `tax_code_`|`GST_FREE` becomes `@tax_code_gst_free`|
+|Initializer| Description                                                                                                                                               | Example                                                               |
+|---|-----------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+|AdminUserInitializer| First user with `ROLE_ADMINISTRATOR`                                                                                                                      | `@admin_user`                                                         |
+|CustomerUserRoleInitializer| All customer user roles                                                                                                                                   | `@buyer`, `@admin`                                                    |
+|ProductUnitInitializer| All product unit codes prefixed with `unit`                                                                                                               | `@unit_each`                                                          |
+|RootCategoryInitializer| The master catalogs root category                                                                                                                         | `@root_category`                                                      |
+|WarehouseInitializer| The snake case version of the name of each warehouse (Enterprise only) prefixed with `warehouse`                                                          | `Some Warehouse` becomes `@warehouse_some_warehouse`                  |
+|BusinessUnitInitializer| All of the existing business units suffixed with `_business_unit`                                                                                         | `North Office` becomes `@north_office_business_unit`                  |
+|DefaultPriceListInitializer| The default price list                                                                                                                                    | `@default_price_list`                                                 |
+|OrganizationInitializer| If more than one organization exists the normalized name of of the organization prefixed by `org_`. If only one exists it is named `default_organization` | `@default_organization` or `Our Business` becomes `@org_our_business` |
+|SegmentTypeInitializer| The available segment types                                                                                                                               | `@dynamic_segment_type` or `static_segment_type`                      |
+|WebsiteInitializer| All website names prefixed by `website_`                                                                                                                  | `Some Store` becomes `@website_some_store`                            |
+|CustomerGroupInitializer| All customer group names prefixed with `group_`                                                                                                           | `Registered Buyers` becomes `@group_registered_buyers`                |
+|InventoryStatusInitializer| All inventory status ids prefixed by `inventory_status_`                                                                                                  | `@inventory_status_in_stock` or `@inventory_status_out_of_stock`      |
+|ProductFamilyInitializer| All Attribute family names prefixed with `product_family_`                                                                                                | `Clothing Attributes` becomes `@product_family_clothing_attributes`   |
+|CustomerTaxCodeInitializer| The customer tax code lowercased and prefixed with `customer_tax_code_`                                                                                   | `GST_FREE` becomes `@customer_tax_code_gst_free`                      |
 
 Adding and Running Fixtures
 -----------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
-### 4.2.0 Release 
+### 4.2.1 Release 
 
-- Initial Release of bundle
-- Compatible with Oro >= 4.2
+- Rename TaxCodeInitializer to CustomerTaxCodeInitializer and update reference identifier 
+- Fix issue where second fixture fails due to references being removed from entity manager on flush
 

--- a/src/Fixtures/AbstractAliceFixture.php
+++ b/src/Fixtures/AbstractAliceFixture.php
@@ -3,6 +3,7 @@
 namespace Aligent\FixturesBundle\Fixtures;
 
 use Aligent\FixturesBundle\Initializer\ReferenceInitializer;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Persistence\ObjectManager;
 use Fidry\AliceDataFixtures\Loader\PurgerLoader;
@@ -49,8 +50,9 @@ abstract class AbstractAliceFixture extends AbstractFixture implements Container
 
         /** @var ReferenceInitializer $initializer */
         $initializer = $this->container->get(ReferenceInitializer::class);
-        $references = $initializer->getReferences($manager)->toArray();
-        $loader->load($files, [], $references);
+        $references = new ArrayCollection();
+        $initializer->init($manager, $references);
+        $loader->load($files, [], $references->toArray());
     }
 
     /**

--- a/src/Initializer/CustomerTaxCodeInitializer.php
+++ b/src/Initializer/CustomerTaxCodeInitializer.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Persistence\ObjectManager;
 use Oro\Bundle\TaxBundle\Entity\CustomerTaxCode;
 
-class TaxCodeInitializer implements ReferenceInitializerInterface
+class CustomerTaxCodeInitializer implements ReferenceInitializerInterface
 {
     public function init(ObjectManager $manager, Collection $referenceRepository): void
     {
@@ -15,7 +15,7 @@ class TaxCodeInitializer implements ReferenceInitializerInterface
         /** @var CustomerTaxCode $taxCode */
         foreach ($repo->findAll() as $taxCode) {
             $referenceRepository->set(
-                'tax_code_' . strtolower($taxCode->getCode()),
+                'customer_tax_code_' . strtolower($taxCode->getCode()),
                 $taxCode
             );
         }

--- a/src/Initializer/ReferenceInitializer.php
+++ b/src/Initializer/ReferenceInitializer.php
@@ -14,17 +14,11 @@ class ReferenceInitializer implements ReferenceInitializerInterface
     protected iterable $initializers = [];
 
     /**
-     * @var Collection<string, mixed>
-     */
-    protected Collection $references;
-
-    /**
      * @param iterable<ReferenceInitializerInterface> $initializers
      */
     public function __construct(iterable $initializers)
     {
         $this->initializers = $initializers;
-        $this->references = new ArrayCollection();
     }
 
     /**
@@ -40,18 +34,5 @@ class ReferenceInitializer implements ReferenceInitializerInterface
         foreach ($this->getInitializers() as $initializer) {
             $initializer->init($manager, $referenceRepository);
         }
-    }
-
-    /**
-     * @param ObjectManager $manager
-     * @return Collection<string, mixed>
-     */
-    public function getReferences(ObjectManager $manager): Collection
-    {
-        if ($this->references->isEmpty()) {
-            $this->init($manager, $this->references);
-        }
-
-        return $this->references;
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -48,7 +48,7 @@ services:
     tags:
       - { name: demo_fixtures.initializer }
 
-  Aligent\FixturesBundle\Initializer\TaxCodeInitializer:
+  Aligent\FixturesBundle\Initializer\CustomerTaxCodeInitializer:
     tags:
       - { name: demo_fixtures.initializer }
 

--- a/src/Tests/Unit/Initializer/CustomerTaxCodeInitializerTest.php
+++ b/src/Tests/Unit/Initializer/CustomerTaxCodeInitializerTest.php
@@ -1,26 +1,26 @@
 <?php
 namespace Aligent\FixturesBundle\Tests\Unit\Initializer;
 
-use Aligent\FixturesBundle\Initializer\TaxCodeInitializer;
+use Aligent\FixturesBundle\Initializer\CustomerTaxCodeInitializer;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Persistence\ObjectManager;
 use Oro\Bundle\TaxBundle\Entity\CustomerTaxCode;
 use Oro\Bundle\TaxBundle\Entity\Repository\CustomerTaxCodeRepository;
 use PHPUnit\Framework\TestCase;
 
-class TaxCodeInitializerTest extends TestCase
+class CustomerTaxCodeInitializerTest extends TestCase
 {
     public function testInit(): void
     {
-        $initializer = new TaxCodeInitializer();
+        $initializer = new CustomerTaxCodeInitializer();
         $collection = new ArrayCollection();
 
         $manager = $this->createMock(ObjectManager::class);
         $repo = $this->createMock(CustomerTaxCodeRepository::class);
 
         $entities = [
-            'tax_code_gst' => (new CustomerTaxCode())->setCode('GST'),
-            'tax_code_gst_free' => (new CustomerTaxCode())->setCode('GST_FREE'),
+            'customer_tax_code_gst' => (new CustomerTaxCode())->setCode('GST'),
+            'customer_tax_code_gst_free' => (new CustomerTaxCode())->setCode('GST_FREE'),
         ];
 
         $manager->expects($this->once())


### PR DESCRIPTION
This PR just updates the TaxCodeInitializer to CustomerTaxCodeInitializer, and fixes an issue where the second fixture would fail due to the entity references already being cleared from the entity managers memory.