### PR TITLE
Oro 5.0 Support

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPCS

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPStan

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPUnit

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "oro/commerce": "4.2.*",
-        "oro/platform": "^4.2.6"
+        "oro/commerce": "5.0.*",
+        "oro/platform": "5.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
* Bump Composer from Oro 4.2 to Oro 5.0 support
* Update GitHub workflows to use PHP 8.1

NOTE: This has not yet been tested in Oro 5.0, additional fixes may be required after installation.